### PR TITLE
Add Module::Build install system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 *~
+*.patch
+Build
+MANIFEST*.bak
+MYMETA.*
+_build/
+blib/
+*.tmp

--- a/Build.PL
+++ b/Build.PL
@@ -1,0 +1,34 @@
+#! /usr/bin/env perl
+
+use Module::Build;
+
+my $build = Module::Build->new(
+	module_name => "App::KADR",
+	license => "bsd",
+	dist_abstract => "Kulag's AniDB Renamer",
+	dist_version => 1,
+	dist_author => 'Kulag <g.kulag@gmail.com>',
+	script_files => "kadr.pl",
+	requires => {
+		"perl" => "5.14.0",
+		"Class::Load" => "0",
+		"common::sense" => "0",
+		"DBD::SQLite" => "0",
+		"DBI" => "0",
+		"Digest::ED2K" => "0",
+		"Digest::MD4" => "0",
+		"enum" => "0",
+		"Expect" => "0",
+		"File::Copy" => "0",
+		"File::Find" => "0",
+		"File::Spec::Memoized" => "0",
+		"List::AllUtils" => "0",
+		"Moose" => "0",
+		"MooseX::Getopt" => "0",
+		"MooseX::SimpleConfig" => "0",
+		"MooseX::Types::Stringlike" => "0",
+		"Template" => "0",
+	},
+);
+
+$build->create_build_script;

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,19 @@
+Build.PL
+kadr.pl
+lib/App/KADR/AniDB/EpisodeNumber.pm
+lib/App/KADR/AniDB/EpisodeNumber/Range.pm
+lib/App/KADR/AniDB/UDP/Client.pm
+lib/App/KADR/Config.pm
+lib/App/KADR/Path.pm
+lib/App/KADR/Path/Dir.pm
+lib/App/KADR/Path/Entity.pm
+lib/App/KADR/Path/File.pm
+lib/App/KADR/Term/StatusLine.pm
+lib/App/KADR/Term/StatusLine/Fractional.pm
+lib/App/KADR/Term/StatusLine/Freeform.pm
+lib/App/KADR/Term/StatusLine/XofX.pm
+MANIFEST			This list of files
+README
+t/episode_number.t
+META.yml
+META.json

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,0 +1,73 @@
+
+#!start included /usr/lib/perl5/5.14/ExtUtils/MANIFEST.SKIP
+# Avoid version control files.
+\bRCS\b
+\bCVS\b
+\bSCCS\b
+,v$
+\B\.svn\b
+\B\.git\b
+\B\.gitignore\b
+\b_darcs\b
+\B\.cvsignore$
+
+# Avoid VMS specific MakeMaker generated files
+\bDescrip.MMS$
+\bDESCRIP.MMS$
+\bdescrip.mms$
+
+# Avoid Makemaker generated and utility files.
+\bMANIFEST\.bak
+\bMakefile$
+\bblib/
+\bMakeMaker-\d
+\bpm_to_blib\.ts$
+\bpm_to_blib$
+\bblibdirs\.ts$         # 6.18 through 6.25 generated this
+
+# Avoid Module::Build generated and utility files.
+\bBuild$
+\b_build/
+\bBuild.bat$
+\bBuild.COM$
+\bBUILD.COM$
+\bbuild.com$
+
+# Avoid temp and backup files.
+~$
+\.old$
+\#$
+\b\.#
+\.bak$
+\.tmp$
+\.#
+\.rej$
+
+# Avoid OS-specific files/dirs
+# Mac OSX metadata
+\B\.DS_Store
+# Mac OSX SMB mount metadata files
+\B\._
+
+# Avoid Devel::Cover and Devel::CoverX::Covered files.
+\bcover_db\b
+\bcovered\b
+
+# Avoid MYMETA files
+^MYMETA\.
+#!end included /usr/lib/perl5/5.14/ExtUtils/MANIFEST.SKIP
+
+# Avoid configuration metadata file
+^MYMETA\.
+
+# Avoid Module::Build generated and utility files.
+\bBuild$
+\bBuild.bat$
+\b_build
+\bBuild.COM$
+\bBUILD.COM$
+\bbuild.com$
+^MANIFEST\.SKIP
+
+# Avoid archives of this distribution
+\bApp-KADR-[\d\.\_]+

--- a/META.json
+++ b/META.json
@@ -1,0 +1,102 @@
+{
+   "abstract" : "Kulag's AniDB Renamer",
+   "author" : [
+      "Kulag <g.kulag.com>"
+   ],
+   "dynamic_config" : 1,
+   "generated_by" : "Module::Build version 0.4003, CPAN::Meta::Converter version 2.112150",
+   "license" : [
+      "bsd"
+   ],
+   "meta-spec" : {
+      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
+      "version" : "2"
+   },
+   "name" : "App-KADR",
+   "prereqs" : {
+      "configure" : {
+         "requires" : {
+            "Module::Build" : "0.40"
+         }
+      },
+      "runtime" : {
+         "requires" : {
+            "Class::Load" : 0,
+            "DBD::SQLite" : 0,
+            "DBI" : 0,
+            "Digest::ED2K" : 0,
+            "Digest::MD4" : 0,
+            "Expect" : 0,
+            "File::Copy" : 0,
+            "File::Find" : 0,
+            "File::Spec::Memoized" : 0,
+            "List::AllUtils" : 0,
+            "Moose" : 0,
+            "MooseX::Getopt" : 0,
+            "MooseX::SimpleConfig" : 0,
+            "MooseX::Types::Stringlike" : 0,
+            "Template" : 0,
+            "common::sense" : 0,
+            "enum" : 0,
+            "perl" : "v5.14.0"
+         }
+      }
+   },
+   "provides" : {
+      "App::KADR::AniDB::EpisodeNumber" : {
+         "file" : "lib/App/KADR/AniDB/EpisodeNumber.pm",
+         "version" : 0
+      },
+      "App::KADR::AniDB::EpisodeNumber::Range" : {
+         "file" : "lib/App/KADR/AniDB/EpisodeNumber/Range.pm",
+         "version" : 0
+      },
+      "App::KADR::AniDB::UDP::Client" : {
+         "file" : "lib/App/KADR/AniDB/UDP/Client.pm",
+         "version" : 0
+      },
+      "App::KADR::Config" : {
+         "file" : "lib/App/KADR/Config.pm",
+         "version" : 0
+      },
+      "App::KADR::Path" : {
+         "file" : "lib/App/KADR/Path.pm",
+         "version" : 0
+      },
+      "App::KADR::Path::Dir" : {
+         "file" : "lib/App/KADR/Path/Dir.pm",
+         "version" : 0
+      },
+      "App::KADR::Path::Entity" : {
+         "file" : "lib/App/KADR/Path/Entity.pm",
+         "version" : 0
+      },
+      "App::KADR::Path::File" : {
+         "file" : "lib/App/KADR/Path/File.pm",
+         "version" : 0
+      },
+      "App::KADR::Term::StatusLine" : {
+         "file" : "lib/App/KADR/Term/StatusLine.pm",
+         "version" : 0
+      },
+      "App::KADR::Term::StatusLine::Fractional" : {
+         "file" : "lib/App/KADR/Term/StatusLine/Fractional.pm",
+         "version" : 0
+      },
+      "App::KADR::Term::StatusLine::Freeform" : {
+         "file" : "lib/App/KADR/Term/StatusLine/Freeform.pm",
+         "version" : 0
+      },
+      "App::KADR::Term::StatusLine::XofX" : {
+         "file" : "lib/App/KADR/Term/StatusLine/XofX.pm",
+         "version" : 0
+      }
+   },
+   "release_status" : "stable",
+   "resources" : {
+      "license" : [
+         "http://opensource.org/licenses/bsd-license.php"
+      ]
+   },
+   "version" : "1"
+}

--- a/META.yml
+++ b/META.yml
@@ -1,0 +1,73 @@
+---
+abstract: "Kulag's AniDB Renamer"
+author:
+  - 'Kulag <g.kulag.com>'
+build_requires: {}
+configure_requires:
+  Module::Build: 0.40
+dynamic_config: 1
+generated_by: 'Module::Build version 0.4003, CPAN::Meta::Converter version 2.112150'
+license: bsd
+meta-spec:
+  url: http://module-build.sourceforge.net/META-spec-v1.4.html
+  version: 1.4
+name: App-KADR
+provides:
+  App::KADR::AniDB::EpisodeNumber:
+    file: lib/App/KADR/AniDB/EpisodeNumber.pm
+    version: 0
+  App::KADR::AniDB::EpisodeNumber::Range:
+    file: lib/App/KADR/AniDB/EpisodeNumber/Range.pm
+    version: 0
+  App::KADR::AniDB::UDP::Client:
+    file: lib/App/KADR/AniDB/UDP/Client.pm
+    version: 0
+  App::KADR::Config:
+    file: lib/App/KADR/Config.pm
+    version: 0
+  App::KADR::Path:
+    file: lib/App/KADR/Path.pm
+    version: 0
+  App::KADR::Path::Dir:
+    file: lib/App/KADR/Path/Dir.pm
+    version: 0
+  App::KADR::Path::Entity:
+    file: lib/App/KADR/Path/Entity.pm
+    version: 0
+  App::KADR::Path::File:
+    file: lib/App/KADR/Path/File.pm
+    version: 0
+  App::KADR::Term::StatusLine:
+    file: lib/App/KADR/Term/StatusLine.pm
+    version: 0
+  App::KADR::Term::StatusLine::Fractional:
+    file: lib/App/KADR/Term/StatusLine/Fractional.pm
+    version: 0
+  App::KADR::Term::StatusLine::Freeform:
+    file: lib/App/KADR/Term/StatusLine/Freeform.pm
+    version: 0
+  App::KADR::Term::StatusLine::XofX:
+    file: lib/App/KADR/Term/StatusLine/XofX.pm
+    version: 0
+requires:
+  Class::Load: 0
+  DBD::SQLite: 0
+  DBI: 0
+  Digest::ED2K: 0
+  Digest::MD4: 0
+  Expect: 0
+  File::Copy: 0
+  File::Find: 0
+  File::Spec::Memoized: 0
+  List::AllUtils: 0
+  Moose: 0
+  MooseX::Getopt: 0
+  MooseX::SimpleConfig: 0
+  MooseX::Types::Stringlike: 0
+  Template: 0
+  common::sense: 0
+  enum: 0
+  perl: v5.14.0
+resources:
+  license: http://opensource.org/licenses/bsd-license.php
+version: 1


### PR DESCRIPTION
Hopefully I didn't miss any dependency ;)

Meant to be used with `./Build.PL && ./Build installdeps`. Since KADR (hopefully) keeps all its settings in the homedir it can even be actually `install`ed.
