### PR TITLE
Add YAML::XS dep, regenerate META files

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -28,6 +28,7 @@ my $build = Module::Build->new(
 		"MooseX::SimpleConfig" => "0",
 		"MooseX::Types::Stringlike" => "0",
 		"Template" => "0",
+		"YAML::XS" => "0",
 	},
 );
 

--- a/META.json
+++ b/META.json
@@ -1,7 +1,7 @@
 {
    "abstract" : "Kulag's AniDB Renamer",
    "author" : [
-      "Kulag <g.kulag.com>"
+      "Kulag <g.kulag@gmail.com>"
    ],
    "dynamic_config" : 1,
    "generated_by" : "Module::Build version 0.4003, CPAN::Meta::Converter version 2.112150",
@@ -36,6 +36,7 @@
             "MooseX::SimpleConfig" : 0,
             "MooseX::Types::Stringlike" : 0,
             "Template" : 0,
+            "YAML::XS" : 0,
             "common::sense" : 0,
             "enum" : 0,
             "perl" : "v5.14.0"

--- a/META.yml
+++ b/META.yml
@@ -1,7 +1,7 @@
 ---
 abstract: "Kulag's AniDB Renamer"
 author:
-  - 'Kulag <g.kulag.com>'
+  - 'Kulag <g.kulag@gmail.com>'
 build_requires: {}
 configure_requires:
   Module::Build: 0.40
@@ -65,6 +65,7 @@ requires:
   MooseX::SimpleConfig: 0
   MooseX::Types::Stringlike: 0
   Template: 0
+  YAML::XS: 0
   common::sense: 0
   enum: 0
   perl: v5.14.0


### PR DESCRIPTION
The config file loader (indirectly) uses Config::Any but hardcodes a .yml file so it requires YAML anyway. The pure perl YAML module is quite buggy so we use the libyaml one (YAML::XS).

META.\* were regenerated to incorporate changes.
