### PR TITLE
Add hash_only option

### DIFF
--- a/kadr.pl
+++ b/kadr.pl
@@ -85,13 +85,16 @@ if($conf->load_local_cache_into_memory) {
 	]);
 }
 
-my $a = App::KADR::AniDB::UDP::Client->new({
-	username => $conf->anidb_username,
-	password => $conf->anidb_password,
-	time_to_sleep_when_busy => $conf->time_to_sleep_when_busy,
-	max_attempts => $conf->query_attempts,
-	timeout => $conf->query_timeout,
-});
+my $a;
+unless ($conf->hash_only) {
+	$a = App::KADR::AniDB::UDP::Client->new({
+		username => $conf->anidb_username,
+		password => $conf->anidb_password,
+		time_to_sleep_when_busy => $conf->time_to_sleep_when_busy,
+		max_attempts => $conf->query_attempts,
+		timeout => $conf->query_timeout,
+	});
+}
 
 # Path template.
 my $pathname_filter
@@ -130,11 +133,11 @@ for my $file (@files) {
 		next;
 	}
 	push @ed2k_of_processed_files, my $ed2k = ed2k_hash($file, $file_size, $mtime);
-	process_file($file, $ed2k, $file_size);
+	process_file($file, $ed2k, $file_size) unless $conf->hash_only;
 }
 $sl->finalize;
 
-if ($conf->update_anidb_records_for_deleted_files) {
+if ($conf->update_anidb_records_for_deleted_files && !$conf->hash_only) {
 	update_mylist_state_for_missing_files(\@ed2k_of_processed_files, $a->MYLIST_STATE_DELETED);
 }
 
@@ -379,7 +382,7 @@ sub ed2k_hash {
 		return $r->{ed2k};
 	}
 
-	if($conf->has_avdump) {
+	if($conf->has_avdump && !$conf->hash_only) {
 		return avdump($file, $size, $mtime);
 	}
 

--- a/lib/App/KADR/Config.pm
+++ b/lib/App/KADR/Config.pm
@@ -125,6 +125,12 @@ EOF
 	isa => 'Str',
 	required => 1;
 
+has 'hash_only',
+	default => 0,
+	documentation => "Do not connect to AniDB, avdump or move files around; only hashes.",
+	is => 'rw',
+	isa => 'Bool';
+
 has 'load_local_cache_into_memory' => (is => 'rw', isa => 'Bool', default => 1, documentation => "Disable to reduce memory usage when doing a longer run. About 15 times faster when kadr doesn't have to talk to anidb.");
 
 has 'query_attempts',


### PR DESCRIPTION
Skips doing anything that might require a network connection, thus
effectively only hashing. This could be improved to also, say,
rename all files to conform to a new naming scheme, but the current
cache expiration system doesn't allow that.
